### PR TITLE
chore(deps): update charming-actions to 2.7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023-2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Release to latest/edge
 
 on:
@@ -18,10 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.1.1
+        uses: canonical/charming-actions/channel@2.7.0
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.1
+        uses: canonical/charming-actions/upload-charm@2.7.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ commands =
 description = Run unit tests.
 deps =
     ops[testing]==2.17.1
+    ops-scenario==7.0.5
     pyfakefs==5.7.4
     pytest
     coverage[toml]


### PR DESCRIPTION
Small PR to bump the version of charming actions to 2.7.0 so that the new version of the SSSD charm can be published to Charmhub. The current Release workflow is failing because the version of `charming-actions` is old enough that it is still looking for the _metadata.yaml_ file which obviously doesn't exist anymore. 