### PR TITLE
feat: add tf module for sssd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ __pycache__/
 .idea
 .vscode/
 .charmhub.secret
+cover
+.terraform
+.terraform.lock.hcl
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -22,7 +22,6 @@ This module offers the following configurable units:
 | `app_name`    | string      | Application name                                         | sssd         |          |
 | `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
 | `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
-| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
 | `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
 | `revision`    | number      | Revision number of charm to deploy                       | null         |          |
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,48 @@
+# Terraform module for sssd
+
+This is a Terraform module facilitating the deployment of the sssd charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+This module requires a Juju model to be available. Refer to the [usage](#usage)
+section for more details.
+
+## API
+
+### Inputs
+
+This module offers the following configurable units:
+
+| Name          | Type        | Description                                              | Default      | Required |
+|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
+| `app_name`    | string      | Application name                                         | sssd         |          |
+| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
+| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
+| `constraints` | string      | Constraints for the charm deployment                     | "arch=amd64" |          |
+| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
+| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+
+### Outputs
+
+After applying, the module exports the following outputs:
+
+| Name       | Description                 |
+|------------|-----------------------------|
+| `app_name` | Application name            |
+| `requires` | Map of `requires` endpoints |
+
+## Usage
+
+Users should ensure that Terraform is aware of the Juju model dependency of the
+charm module.
+
+To deploy this module with its required dependency, you can run
+the following command:
+
+```shell
+terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,5 @@ resource "juju_application" "sssd" {
     revision = var.revision
   }
 
-  constraints = var.constraints
-  units       = 0
+  units = 0
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,28 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "sssd" {
+  name  = var.app_name
+  model = var.model_name
+
+  charm {
+    name     = "sssd"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  constraints = var.constraints
+  units       = 0
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,25 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "app_name" {
+  value = juju_application.sssd.name
+}
+
+output "requires" {
+  value = {
+    juju-info       = "juju-info"
+    ldap            = "ldap"
+    receive-ca-cert = "receive-ca-cert"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,12 +30,6 @@ variable "channel" {
   default     = "latest/edge"
 }
 
-variable "constraints" {
-  description = "Deployment constraints"
-  type        = string
-  default     = "arch=amd64"
-}
-
 variable "model_name" {
   description = "Model name"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,49 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "sssd"
+}
+
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "constraints" {
+  description = "Deployment constraints"
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  nullable    = true
+  default     = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,22 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.16.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a Terraform module for deploying the SSSD operator with Charmed HPC deployment plans. Key things to note are that I have left off the `config` and `units` variables as the SSSD charm. The charm currently has no configuration options - _that may change as we start allowing users to log into `sackd` nodes via ssh_ - and subordinate operators cannot be deployed with a set number of units.