### PR TITLE
chore: bump juju terraform provider version

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,4 @@ resource "juju_application" "sssd" {
     channel  = var.channel
     revision = var.revision
   }
-
-  units = 0
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.16.0"
+      version = ">= 0.19.0"
     }
   }
 }


### PR DESCRIPTION
Bumps the Juju Terraform provider to 0.19.0, which comes with a change that obviates the need for the `units` parameter on subordinate charms.