### PR TITLE
feat: update terraform module to juju provider ~> 1.0

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,13 +17,13 @@ section for more details.
 
 This module offers the following configurable units:
 
-| Name          | Type        | Description                                              | Default      | Required |
-|---------------|-------------|----------------------------------------------------------|--------------|:--------:|
-| `app_name`    | string      | Application name                                         | sssd         |          |
-| `base`        | string      | Base version to use for deployed machine                 | ubuntu@24.04 |          |
-| `channel`     | string      | Channel that charm is deployed from                      | latest/edge  |          |
-| `model_name`  | string      | Name of the model to deploy the charm to                 |              |    Y     |
-| `revision`    | number      | Revision number of charm to deploy                       | null         |          |
+| Name         | Type        | Description                              | Default      | Required |
+|--------------|-------------|------------------------------------------|--------------|:--------:|
+| `app_name`   | string      | Application name                         | sssd         |          |
+| `base`       | string      | Base version to use for deployed machine | ubuntu@24.04 |          |
+| `channel`    | string      | Channel that charm is deployed from      | latest/edge  |          |
+| `model_uuid` | string      | UUID of the model to deploy the charm to |              |    Y     |
+| `revision`   | number      | Revision number of charm to deploy       | null         |          |
 
 ### Outputs
 
@@ -43,5 +43,5 @@ To deploy this module with its required dependency, you can run
 the following command:
 
 ```shell
-terraform apply -var="model_name=<MODEL_NAME>" -auto-approve
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
 ```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "sssd" {
-  name  = var.app_name
-  model = var.model_name
+  name       = var.app_name
+  model_uuid = var.model_uuid
 
   charm {
     name     = "sssd"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 variable "app_name" {
-  description = "Application name"
+  description = "The Juju application name"
   type        = string
   default     = "sssd"
 }
@@ -30,8 +30,8 @@ variable "channel" {
   default     = "latest/edge"
 }
 
-variable "model_name" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.19.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
Tiny PR that updates the SSSD charm's Terraform module to use v1 of the Juju Terraform provider. The most noticeable change is that the `juju_application` resource now expects `model_uuid` instead of `model_name`.