### PR TITLE
feat: update terraform module to be compliant with CC008 specification

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -8,39 +8,51 @@ for the Juju Terraform provider.
 
 ## Requirements
 
-This module requires a Juju model to be available. Refer to the [usage](#usage)
-section for more details.
+- Terraform >= 1.0
+- Juju Terraform provider >= 1.0.0, < 2.0.0
+- An existing Juju model
 
 ## API
 
 ### Inputs
 
-This module offers the following configurable units:
-
-| Name         | Type        | Description                              | Default      | Required |
-|--------------|-------------|------------------------------------------|--------------|:--------:|
-| `app_name`   | string      | Application name                         | sssd         |          |
-| `base`       | string      | Base version to use for deployed machine | ubuntu@24.04 |          |
-| `channel`    | string      | Channel that charm is deployed from      | latest/edge  |          |
-| `model_uuid` | string      | UUID of the model to deploy the charm to |              |    Y     |
-| `revision`   | number      | Revision number of charm to deploy       | null         |          |
+| Name          | Type        | Description                                                        | Default         | Required |
+|---------------|-------------|--------------------------------------------------------------------|-----------------|:--------:|
+| `app_name`    | string      | The Juju application name                                          | `"sssd"`        |          |
+| `base`        | string      | Operating system base (for example, `ubuntu@24.04`)                | `null`          |          |
+| `channel`     | string      | Charm channel to deploy from                                       | `"latest/beta"` |          |
+| `config`      | map(string) | Map of charm configuration options                                 | `{}`            |          |
+| `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                 |    Y     |
+| `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`          |          |
 
 ### Outputs
 
-After applying, the module exports the following outputs:
+| Name          | Description                              |
+|---------------|------------------------------------------|
+| `application` | The deployed `juju_application` resource |
+| `requires`    | Map of `requires` endpoint names         |
 
-| Name       | Description                 |
-|------------|-----------------------------|
-| `app_name` | Application name            |
-| `requires` | Map of `requires` endpoints |
+The `requires` output exposes the following endpoint names:
+
+| Key               | Endpoint name     |
+|-------------------|-------------------|
+| `juju-info`       | `juju-info`       |
+| `ldap`            | `ldap`            |
+| `receive-ca-cert` | `receive-ca-cert` |
 
 ## Usage
 
-Users should ensure that Terraform is aware of the Juju model dependency of the
-charm module.
+Ensure that Terraform is aware of the Juju model dependency of the charm module.
 
-To deploy this module with its required dependency, you can run
-the following command:
+```hcl
+module "sssd" {
+  source     = "git::https://github.com/canonical/sssd-operator//terraform"
+  model_uuid = juju_model.my_model.uuid
+}
+```
+
+To deploy this module with its required dependency, you can run the following
+command:
 
 ```shell
 terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "juju_application" "sssd" {
-  name       = var.app_name
-  model_uuid = var.model_uuid
+  name        = var.app_name
+  model_uuid  = var.model_uuid
 
   charm {
     name     = "sssd"
@@ -22,4 +22,6 @@ resource "juju_application" "sssd" {
     channel  = var.channel
     revision = var.revision
   }
+
+  config = var.config
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,16 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "application" {
-  description = "The deployed sssd juju_application resource"
-  value       = juju_application.sssd
-}
-
-output "requires" {
-  description = "Map of requires endpoint names"
-  value = {
-    juju-info       = "juju-info"
-    ldap            = "ldap"
-    receive-ca-cert = "receive-ca-cert"
-  }
-}
+provider "juju" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 terraform {
+  required_version = ">= 1.0"
+
   required_providers {
     juju = {
       source  = "juju/juju"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,24 +19,31 @@ variable "app_name" {
 }
 
 variable "base" {
-  description = "Charm base"
+  description = "Operating system base to use for the deployed application (for example, ubuntu@24.04)"
   type        = string
-  default     = "ubuntu@24.04"
+  default     = null
 }
 
 variable "channel" {
-  description = "Charm channel"
+  description = "Charm channel to deploy from"
   type        = string
-  default     = "latest/edge"
+  default     = "latest/beta"
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
 }
 
 variable "model_uuid" {
-  description = "Model UUID"
+  description = "UUID of the Juju model to deploy the charm into"
   type        = string
+  nullable    = false
 }
 
 variable "revision" {
-  description = "Charm revision"
+  description = "Charm revision to deploy. Null deploys the latest on the given channel"
   type        = number
   nullable    = true
   default     = null


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the SSSD charm's Terraform modules to comply with the [CC008 specification](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?usp=sharing). The most notable change is that the entire `juju_application` resource is included in the Terraform module output rather than just the application name.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Quality of life update to the SSSD charm.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Changes to the documentation will be updated once all our charms are updated to be compliant with the CC008 specification.