### PR TITLE
chore: migrate repo to the canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-**              @charmed-hpc/python-reviewers
-**/terraform    @charmed-hpc/terraform-reviewers
+** @canonical/hpc-code-reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Pre-submission checklist
+
+ * [ ] I read and followed the CONTRIBUTING guidelines.
+ * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.
+
+[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)
+
+## Summary of changes
+
+[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)
+
+
+
+#### Related Issues, PRs, and Discussions
+
+[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)
+
+
+
+## Docs
+
+* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.
+
+[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)
+
+Or:
+
+* [ ] I confirm that this pull request requires no changes or additions to documentation.
+
+[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ![GitHub License](https://img.shields.io/github/license/canonical/sssd-operator)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#hpc:ubuntu.com)
 
-A [Juju](https://juju.is) charm for automating the full lifecycle operations of 
-[SSSD](https://sssd.io) (System Security Services Daemon), a system service to access 
+A [Juju](https://juju.is) charm for automating the full lifecycle operations of
+[SSSD](https://sssd.io) (System Security Services Daemon), a system service to access
 remote directories and authentication mechanisms such as LDAP, Kerberos, or FreeIPA.
 
 ## ✨ Getting Started
@@ -33,7 +33,6 @@ further resources for you to explore:
 
 * [Charmed HPC documentation](https://documentation.ubuntu.com/charmed-hpc)
 * [Open an issue](https://github.com/canonical/sssd-operator/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
-* [Ask a question on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 🛠️ Development
 
@@ -66,7 +65,7 @@ If you're interested in contributing, take a look at our [contributing guideline
 ## 🤝 Project and community
 
 The SSSD operator is a project of the [Ubuntu High-Performance Computing community](https://ubuntu.com/community/governance/teams/hpc).
-Interested in contributing bug fixes, patches, documentation, or feedback? Want to join the 
+Interested in contributing bug fixes, patches, documentation, or feedback? Want to join the
 Ubuntu HPC community? You've come to the right place 🤩
 
 Here's some links to help you get started with joining the community:
@@ -75,13 +74,12 @@ Here's some links to help you get started with joining the community:
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
 * [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
-* [Ask and answer questions on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 📋 License
 
 The SSSD operator is free software, distributed under the Apache Software License, version 2.0.
 See the [Apache-2.0 LICENSE](./LICENSE) file for further details.
 
-SSSD is licensed under the GNU General Public License, version 3.0. 
+SSSD is licensed under the GNU General Public License, version 3.0.
 See the upstream SSSD [COPYING](https://github.com/SSSD/sssd/blob/master/COPYING) file
 for further licensing information about SSSD.


### PR DESCRIPTION
Migrate all our references to the charmed-hpc org to the canonical org equivalent.